### PR TITLE
Increased Vagrant VM memory

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
      #vb.gui = true
 
      # Use VBoxManage to customize the VM. For example to change memory:
-     vb.customize ["modifyvm", :id, "--memory", "1024"]
+     vb.customize ["modifyvm", :id, "--memory", "2048"]
    end
   #
   # View the documentation for the provider you're using for more


### PR DESCRIPTION
We've found that Postgresql often requires more than 1GB of memory.
